### PR TITLE
Streams being transformed into one another

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SOURCE_FILES lexer.cpp ast.cpp parser.cpp codegen.cpp)
 
 add_library(compiler_lib ${SOURCE_FILES})
-target_link_libraries(compiler_lib Boost::program_options spdlog::spdlog
+target_link_libraries(compiler_lib Boost::program_options spdlog::spdlog gtest
                       ${LLVM_LIBS})
 
 add_executable(compiler compiler.cpp)

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -116,6 +116,7 @@ public:
 using ParsedAstContentType = std::variant<
     std::unique_ptr<FunctionAST>,
     std::unique_ptr<FunctionPrototypeAST>,
-    std::unique_ptr<ExprAST>>;
+    std::unique_ptr<ExprAST>,
+    std::monostate>;
 
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6,7 +6,7 @@ namespace kccani
 
 {
 
-std::variant<llvm::Value*, llvm::Function*> CodeGeneratorLLVM::operator()(std::unique_ptr<ExprAST>&& ast)
+CodegenContentType CodeGeneratorLLVM::operator()(std::unique_ptr<ExprAST>&& ast)
 {
     switch (ast->get_type())
     {
@@ -80,7 +80,7 @@ std::variant<llvm::Value*, llvm::Function*> CodeGeneratorLLVM::operator()(std::u
     }
 }
 
-std::variant<llvm::Value*, llvm::Function*> CodeGeneratorLLVM::operator()(std::unique_ptr<FunctionAST>&& ast)
+CodegenContentType CodeGeneratorLLVM::operator()(std::unique_ptr<FunctionAST>&& ast)
 {
     // First, check for an existing function from a previous 'extern' declaration.
     llvm::Function *the_function = this->module->getFunction(ast->prototype->name);
@@ -110,7 +110,7 @@ std::variant<llvm::Value*, llvm::Function*> CodeGeneratorLLVM::operator()(std::u
     return (llvm::Function*) nullptr;
 }
 
-std::variant<llvm::Value*, llvm::Function*> CodeGeneratorLLVM::operator()(std::unique_ptr<FunctionPrototypeAST>&& ast)
+CodegenContentType CodeGeneratorLLVM::operator()(std::unique_ptr<FunctionPrototypeAST>&& ast)
 {
     std::vector<llvm::Type*> doubles(ast->args.size(), llvm::Type::getDoubleTy(*this->context));
     llvm::FunctionType *function_type = llvm::FunctionType::get(
@@ -123,6 +123,11 @@ std::variant<llvm::Value*, llvm::Function*> CodeGeneratorLLVM::operator()(std::u
         arg.setName(ast->args[idx++]);
 
     return function;
+}
+
+CodegenContentType CodeGeneratorLLVM::operator()(std::monostate&& invalid)
+{
+    return std::monostate{};
 }
 
 void CodeGeneratorLLVM::print() const

--- a/src/codegen.hpp
+++ b/src/codegen.hpp
@@ -13,6 +13,11 @@
 namespace kccani
 {
 
+using CodegenContentType = std::variant<
+    llvm::Value*,
+    llvm::Function*,
+    std::monostate>;
+
 class CodeGeneratorLLVM
 {
     std::unique_ptr<llvm::LLVMContext> context{std::make_unique<llvm::LLVMContext>()};
@@ -21,9 +26,10 @@ class CodeGeneratorLLVM
     std::map<std::string, llvm::Value*> named_values;
 
 public:
-    std::variant<llvm::Value*, llvm::Function*> operator()(std::unique_ptr<ExprAST>&& ast);
-    std::variant<llvm::Value*, llvm::Function*> operator()(std::unique_ptr<FunctionAST>&& ast);
-    std::variant<llvm::Value*, llvm::Function*> operator()(std::unique_ptr<FunctionPrototypeAST>&& ast);
+    CodegenContentType operator()(std::unique_ptr<ExprAST>&& ast);
+    CodegenContentType operator()(std::unique_ptr<FunctionAST>&& ast);
+    CodegenContentType operator()(std::unique_ptr<FunctionPrototypeAST>&& ast);
+    CodegenContentType operator()(std::monostate&& ast);
 
     void print() const;
 };

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -52,26 +52,21 @@ int main(int argc, char* argv[])
     }
     else
     {
+        auto lexer = kccani::Lexer(std::cin);
+        auto parser = kccani::Parser(lexer);
         kccani::CodeGeneratorLLVM codegen;
         while (true)
         {
             std::cout << "kccani> ";
-            std::string input_string;
-            getline(std::cin, input_string);
-            std::stringstream input_stream(input_string);
+            auto ast = parser.get();
 
-            auto lexer = kccani::Lexer(input_stream);
-            auto parser = kccani::Parser(lexer);
-            auto ast_stream = parser.fetch_all();
-            for (auto &ast : ast_stream)
-            {
-                auto result = std::visit(std::ref(codegen), std::move(ast));
-                if (std::holds_alternative<llvm::Function*>(result))
-                    std::cout << std::get<llvm::Function*>(result) << std::endl;
-                else if (std::holds_alternative<llvm::Value*>(result))
-                    std::cout << std::get<llvm::Value*>(result) << std::endl;
-            }
-            codegen.print();
+            auto result = std::visit(std::ref(codegen), std::move(ast));
+            if (std::holds_alternative<llvm::Function*>(result))
+                std::cout << std::get<llvm::Function*>(result) << std::endl;
+            else if (std::holds_alternative<llvm::Value*>(result))
+                std::cout << std::get<llvm::Value*>(result) << std::endl;
+            else
+                std::cout << "Error in Code Generation" << std::endl;
         }
     }
 }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -39,8 +39,8 @@ int main(int argc, char* argv[])
             std::cout << "Compiling: " << file_name << std::endl;
             std::ifstream fin(file_name, std::fstream::in);
 
-            auto tokens = kccani::tokenize(fin);
-            auto asts = kccani::parse_program(tokens);
+            auto lexer = kccani::Lexer(fin);
+            auto asts = kccani::parse_program(lexer);
 
             kccani::CodeGeneratorLLVM codegen;
             for (auto &ast : asts)
@@ -59,8 +59,8 @@ int main(int argc, char* argv[])
             getline(std::cin, input_string);
             std::stringstream input_stream(input_string);
 
-            auto token_stream = kccani::tokenize(input_stream);
-            auto ast_stream = kccani::parse_program(token_stream);
+            auto lexer = kccani::Lexer(input_stream);
+            auto ast_stream = kccani::parse_program(lexer);
             for (auto &ast : ast_stream)
             {
                 auto result = std::visit(std::ref(codegen), std::move(ast));

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -40,7 +40,8 @@ int main(int argc, char* argv[])
             std::ifstream fin(file_name, std::fstream::in);
 
             auto lexer = kccani::Lexer(fin);
-            auto asts = kccani::parse_program(lexer);
+            auto parser = kccani::Parser(lexer);
+            auto asts = parser.fetch_all();
 
             kccani::CodeGeneratorLLVM codegen;
             for (auto &ast : asts)
@@ -60,7 +61,8 @@ int main(int argc, char* argv[])
             std::stringstream input_stream(input_string);
 
             auto lexer = kccani::Lexer(input_stream);
-            auto ast_stream = kccani::parse_program(lexer);
+            auto parser = kccani::Parser(lexer);
+            auto ast_stream = parser.fetch_all();
             for (auto &ast : ast_stream)
             {
                 auto result = std::visit(std::ref(codegen), std::move(ast));

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -54,21 +54,27 @@ Token::operator bool()
     return std::get<char>(this->data.value()) == other;
 }
 
-char stream_char = ' ';
 
-Token get_token(std::istream& fin)
+Token Lexer::get()
 {
-    fin >> std::noskipws;
+    if (this->buffered_token)
+    {
+        auto output_value = this->buffered_token.value();
+        this->buffered_token.reset();
+        return output_value;
+    }
+
+    this->input_stream >> std::noskipws;
 
     while (stream_char == ' ')
-        fin >> stream_char;
+        input_stream >> stream_char;
 
     if (isalpha(stream_char))
     {
         std::string token = "";
         do {
             token += stream_char;
-            fin >> stream_char;
+            input_stream >> stream_char;
         } while (isalnum(stream_char));
 
         if (token == "def")
@@ -83,7 +89,7 @@ Token get_token(std::istream& fin)
         std::string token = "";
         do {
             token += stream_char;
-            fin >> stream_char;
+            input_stream >> stream_char;
         } while (isdigit(stream_char) || stream_char == '.');
 
         std::size_t __string_size_v;
@@ -93,28 +99,45 @@ Token get_token(std::istream& fin)
 
     if (stream_char == '#') {
         do {
-            fin >> stream_char;
+            input_stream >> stream_char;
         } while (stream_char != EOF && stream_char != '\n' && stream_char != '\r');
 
         if (stream_char != EOF)
-            return get_token(fin);
+            return get();
     }
 
     char current_char = stream_char;
-    if (fin >> stream_char)
+    if (input_stream >> stream_char)
         return {Token::TokenType::TOKEN_SPECIAL, current_char};
     else
         return Token::TokenType::TOKEN_EOF;
 }
 
-std::deque<Token> tokenize(std::istream& fin)
+Token Lexer::peek()
 {
-    std::deque<Token> all_tokens;
+    if (!this->buffered_token)
+        this->buffered_token = this->get();
+    return this->buffered_token.value();
+}
+
+Lexer::Lexer(std::basic_istream<char>& text_stream) : input_stream(text_stream)
+{
+}
+
+Lexer Lexer::operator>>(Token& output_token)
+{
+    output_token = this->get();
+    return *this;
+}
+
+std::queue<Token> Lexer::fetch_all()
+{
+    std::queue<Token> all_tokens;
     do
     {
-        Token token = get_token(fin);
+        Token token = this->get();
         if (!(token == '\n'))
-            all_tokens.push_back(token);
+            all_tokens.push(token);
     } while (
         all_tokens.empty() ||
         all_tokens.back().type != Token::TokenType::TOKEN_EOF);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -108,7 +108,11 @@ Token Lexer::get()
 
     char current_char = stream_char;
     if (input_stream >> stream_char)
+    {
+        if (current_char == '\n' || current_char == ' ')
+            return this->get();
         return {Token::TokenType::TOKEN_SPECIAL, current_char};
+    }
     else
         return Token::TokenType::TOKEN_EOF;
 }
@@ -136,8 +140,7 @@ std::queue<Token> Lexer::fetch_all()
     do
     {
         Token token = this->get();
-        if (!(token == '\n'))
-            all_tokens.push(token);
+        all_tokens.push(token);
     } while (
         all_tokens.empty() ||
         all_tokens.back().type != Token::TokenType::TOKEN_EOF);

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <cctype>
-#include <deque>
 #include <iostream>
 #include <optional>
+#include <queue>
 #include <variant>
 #include <vector>
 
@@ -41,7 +41,20 @@ public:
     [[nodiscard]] bool operator ==(char other) const noexcept;
 };
 
-Token get_token(std::istream& fin);
-std::deque<Token> tokenize(std::istream& fin);
+
+class Lexer
+{
+    char stream_char = ' ';
+    std::istream& input_stream;
+    std::optional<Token> buffered_token;
+
+public:
+    virtual Token get();
+    virtual Token peek();
+
+    Lexer(std::basic_istream<char>& text_stream);
+    std::queue<Token> fetch_all();
+    Lexer operator>>(Token& output_token);
+};
 
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -243,8 +243,7 @@ ParsedAstContentType Parser::get() {
                 return std::move(expr);
         }
     }
-    // EOF or error token
-    return ParsedAstContentType{std::unique_ptr<FunctionAST>{nullptr}};
+    return std::monostate{};  // EOF or error token
 }
 
 std::vector<ParsedAstContentType> Parser::fetch_all()

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -9,55 +9,49 @@ namespace kccani
 
 // Primary Expression Parsing
 
-std::unique_ptr<ExprAST> parse_number_expr(
-    Lexer& program
-)
+std::unique_ptr<ExprAST> Parser::parse_number_expr()
 {
-    Token number_token = program.get();
+    Token number_token = this->program.get();
     double number_value = std::get<double>(number_token.data.value());
     auto result = std::make_unique<NumberExprAST>(number_value);
     return std::move(result);
 }
 
-std::unique_ptr<ExprAST> parse_parenthesized_expr(
-    Lexer& program
-)
+std::unique_ptr<ExprAST> Parser::parse_parenthesized_expr()
 {
-    program.get();
-    auto expression = parse_expr(program);
+    this->program.get();
+    auto expression = this->parse_expr();
     if (!expression)
     {
         return nullptr;
     }
-    if (!(program.peek() == ')'))
+    if (!(this->program.peek() == ')'))
     {
         spdlog::error("Expected `)` to close parenthesized expression");
         return nullptr;
     }
-    program.get();
+    this->program.get();
     return expression;
 }
 
-std::unique_ptr<ExprAST> parse_identifier_expr(
-    Lexer& program
-)
+std::unique_ptr<ExprAST> Parser::parse_identifier_expr()
 {
     // Extract the identifier name
-    Token identifier = program.get();
+    Token identifier = this->program.get();
     if (identifier.type != Token::TokenType::TOKEN_IDENTIFIER)
         spdlog::error("Expected token should be an identifier, but is not");
     std::string identifier_name = std::get<std::string>(identifier.data.value());
     // If it's not a function call, process it as a variable name
-    if (!(program.peek() == '('))
+    if (!(this->program.peek() == '('))
     {
         return std::make_unique<VariableExprAST>(identifier_name);
     }
     // If it is a function call and has no args, process it as such
-    program.get();
+    this->program.get();
     std::vector<std::unique_ptr<ExprAST>> function_args;
-    if (program.peek() == ')')
+    if (this->program.peek() == ')')
     {
-        program.get();
+        this->program.get();
         return std::make_unique<FunctionCallExprAST>(
             identifier_name, std::move(function_args));
     }
@@ -65,41 +59,39 @@ std::unique_ptr<ExprAST> parse_identifier_expr(
     std::vector<std::unique_ptr<ExprAST>> args;
     while (true)
     {
-        if (auto arg = parse_expr(program))
+        if (auto arg = this->parse_expr())
             args.push_back(std::move(arg));
         else
             return nullptr;
 
-        if (program.peek() == ')')
+        if (this->program.peek() == ')')
         {
-            program.get();
+            this->program.get();
             break;
         }
-        if (!(program.peek() == ','))
+        if (!(this->program.peek() == ','))
         {
             spdlog::error("Expected ')' or ',' after end of expression in argument list");
             return nullptr;
         }
-        program.get();
+        this->program.get();
     }
     return std::make_unique<FunctionCallExprAST>(identifier_name, std::move(args));
 }
 
-std::unique_ptr<ExprAST> parse_primary(
-    Lexer& program
-)
+std::unique_ptr<ExprAST> Parser::parse_primary()
 {
-    if (program.peek().type == Token::TokenType::TOKEN_IDENTIFIER)
+    if (this->program.peek().type == Token::TokenType::TOKEN_IDENTIFIER)
     {
-        return parse_identifier_expr(program);
+        return this->parse_identifier_expr();
     }
-    else if (program.peek().type == Token::TokenType::TOKEN_NUMBER)
+    else if (this->program.peek().type == Token::TokenType::TOKEN_NUMBER)
     {
-        return parse_number_expr(program);
+        return this->parse_number_expr();
     }
-    else if (program.peek() == '(')
+    else if (this->program.peek() == '(')
     {
-        return parse_parenthesized_expr(program);
+        return this->parse_parenthesized_expr();
     }
     else
     {
@@ -110,37 +102,36 @@ std::unique_ptr<ExprAST> parse_primary(
 
 // Binary expressions and assignments
 
-std::unique_ptr<ExprAST> parse_binary_op_rhs(
-    Lexer& program,
+std::unique_ptr<ExprAST> Parser::parse_binary_op_rhs(
     int expression_precedence,
     std::unique_ptr<ExprAST> lhs
 )
 {
     const std::map<char, int> OP_PRECEDENCE = {{'<', 100}, {'+', 200}, {'-', 300}, {'*', 400}};
 
-    while (program.peek().type == Token::TokenType::TOKEN_SPECIAL) {
-        char opcode = std::get<char>(program.peek().data.value());
+    while (this->program.peek().type == Token::TokenType::TOKEN_SPECIAL) {
+        char opcode = std::get<char>(this->program.peek().data.value());
         int token_precedence = OP_PRECEDENCE.count(opcode) != 0
             ? OP_PRECEDENCE.at(opcode)
             : std::numeric_limits<int>::min();
         if (token_precedence < expression_precedence)
             return std::move(lhs);
-        program.get();
+        this->program.get();
 
-        auto rhs = parse_primary(program);
+        auto rhs = this->parse_primary();
         if (!rhs)
             return nullptr;
 
         // if opcode binds less tightly with RHS than the operator after RHS,
         // let the pending operator take RHS as its LHS.
-        if (program.peek().type == Token::TokenType::TOKEN_SPECIAL)
+        if (this->program.peek().type == Token::TokenType::TOKEN_SPECIAL)
         {
-            char next_opcode = std::get<char>(program.peek().data.value());
+            char next_opcode = std::get<char>(this->program.peek().data.value());
             int next_precedence = OP_PRECEDENCE.count(next_opcode) != 0
                 ? OP_PRECEDENCE.at(next_opcode)
                 : std::numeric_limits<int>::min();
             if (token_precedence < next_precedence) {
-                rhs = parse_binary_op_rhs(program, token_precedence + 1, std::move(rhs));
+                rhs = this->parse_binary_op_rhs(token_precedence + 1, std::move(rhs));
                 if (!rhs)
                     return nullptr;
             }
@@ -151,41 +142,37 @@ std::unique_ptr<ExprAST> parse_binary_op_rhs(
     return std::move(lhs);
 }
 
-std::unique_ptr<ExprAST> parse_expr(
-    Lexer& program
-) {
-    auto lhs = parse_primary(program);
+std::unique_ptr<ExprAST> Parser::parse_expr() {
+    auto lhs = this->parse_primary();
     if (!lhs)
         return nullptr;
 
-    return parse_binary_op_rhs(program, 0, std::move(lhs));
+    return this->parse_binary_op_rhs(0, std::move(lhs));
 }
 
 // Parsing function blocks and top level (main code in script)
 
-std::unique_ptr<FunctionPrototypeAST> parse_function_proto(
-    Lexer& program
-)
+std::unique_ptr<FunctionPrototypeAST> Parser::parse_function_proto()
 {
-    if (program.peek().type != Token::TokenType::TOKEN_IDENTIFIER)
+    if (this->program.peek().type != Token::TokenType::TOKEN_IDENTIFIER)
     {
         spdlog::error("Expected function name in prototype");
         return nullptr;
     }
-    std::string function_name = std::get<std::string>(program.get().data.value());
+    std::string function_name = std::get<std::string>(this->program.get().data.value());
 
-    if (!(program.get() == '('))
+    if (!(this->program.get() == '('))
     {
         spdlog::error("Expected '(' in prototype");
         return nullptr;
     }
 
     std::vector<std::string> arguments;
-    while (program.peek().type == Token::TokenType::TOKEN_IDENTIFIER)
+    while (this->program.peek().type == Token::TokenType::TOKEN_IDENTIFIER)
     {
-       arguments.push_back(std::get<std::string>(program.get().data.value()));
+       arguments.push_back(std::get<std::string>(this->program.get().data.value()));
     }
-    if (!(program.get() == ')'))
+    if (!(this->program.get() == ')'))
     {
         spdlog::error("Expected ')' in prototype");
         return nullptr;
@@ -194,25 +181,21 @@ std::unique_ptr<FunctionPrototypeAST> parse_function_proto(
     return std::make_unique<FunctionPrototypeAST>(function_name, std::move(arguments));
 }
 
-std::unique_ptr<FunctionAST> parse_function_definition(
-    Lexer& program
-)
+std::unique_ptr<FunctionAST> Parser::parse_function_definition()
 {
-    program.get();
-    auto prototype = parse_function_proto(program);
+    this->program.get();
+    auto prototype = this->parse_function_proto();
     if (!prototype)
         return nullptr;
-    auto body = parse_expr(program);
+    auto body = this->parse_expr();
     if (!body)
         return nullptr;
     return std::make_unique<FunctionAST>(std::move(prototype), std::move(body));
 }
 
-std::unique_ptr<FunctionAST> parse_top_level_expr(
-    Lexer& program
-)
+std::unique_ptr<FunctionAST> Parser::parse_top_level_expr()
 {
-    auto expr = parse_expr(program);
+    auto expr = this->parse_expr();
     if (!expr)
         return nullptr;
 
@@ -223,46 +206,61 @@ std::unique_ptr<FunctionAST> parse_top_level_expr(
     return std::make_unique<FunctionAST>(std::move(prototype), std::move(expr));
 }
 
-std::unique_ptr<FunctionPrototypeAST> parse_extern(
-    Lexer& program
-)
+std::unique_ptr<FunctionPrototypeAST> Parser::parse_extern()
 {
-    program.get();
-    return parse_function_proto(program);
+    this->program.get();
+    return this->parse_function_proto();
 }
 
-std::vector<ParsedAstContentType> parse_program(Lexer& program) {
-    std::vector<ParsedAstContentType> parsed_asts;
-    while (true)
+Parser::Parser(Lexer& lexer) : program(lexer)
+{
+}
+
+ParsedAstContentType Parser::get() {
+    if (this->program.peek().type != Token::TokenType::TOKEN_EOF)
     {
-        if (program.peek().type == Token::TokenType::TOKEN_EOF)
+        if (this->program.peek() == ';')
         {
-            break;
+            this->program.get();
+            return std::move(this->get());
         }
-        else if (program.peek() == ';')
+        else if (this->program.peek().type == Token::TokenType::TOKEN_DEF)
         {
-            program.get();
-        }
-        else if (program.peek().type == Token::TokenType::TOKEN_DEF)
-        {
-            ParsedAstContentType defn{parse_function_definition(program)};
+            ParsedAstContentType defn{this->parse_function_definition()};
             if (std::get<std::unique_ptr<FunctionAST>>(defn) != nullptr)
-                parsed_asts.emplace_back(std::move(defn));
+                return std::move(defn);
         }
-        else if (program.peek().type == Token::TokenType::TOKEN_EXTERN)
+        else if (this->program.peek().type == Token::TokenType::TOKEN_EXTERN)
         {
-            ParsedAstContentType call{parse_extern(program)};
+            ParsedAstContentType call{this->parse_extern()};
             if (std::get<std::unique_ptr<FunctionPrototypeAST>>(call) != nullptr)
-                parsed_asts.emplace_back(std::move(call));
+                return std::move(call);
         }
         else
         {
-            ParsedAstContentType expr{parse_expr(program)};
+            ParsedAstContentType expr{this->parse_expr()};
             if (std::get<std::unique_ptr<ExprAST>>(expr) != nullptr)
-                parsed_asts.emplace_back(std::move(expr));
+                return std::move(expr);
         }
     }
-    return parsed_asts; 
+    // EOF or error token
+    return ParsedAstContentType{std::unique_ptr<FunctionAST>{nullptr}};
+}
+
+std::vector<ParsedAstContentType> Parser::fetch_all()
+{
+    std::vector<ParsedAstContentType> ast_list;
+    while (this->program.peek().type != Token::TokenType::TOKEN_EOF)
+    {
+        ast_list.push_back(this->get());
+    }
+    return ast_list;
+}
+
+Parser Parser::operator>>(ParsedAstContentType& ast)
+{
+    ast = this->get();
+    return *this;
 }
 
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -8,42 +8,42 @@ namespace kccani
 {
 
 std::unique_ptr<ExprAST> parse_number_expr(
-    std::deque<Token>& program
+    Lexer& program
 );
 std::unique_ptr<ExprAST> parse_parenthesized_expr(
-    std::deque<Token>& program
+    Lexer& program
 );
 std::unique_ptr<ExprAST> parse_identifier_expr(
-    std::deque<Token>& program
+    Lexer& program
 );
 std::unique_ptr<ExprAST> parse_primary(
-    std::deque<Token>& program
+    Lexer& program
 );
 
 std::unique_ptr<ExprAST> parse_binary_op_rhs(
-    std::deque<Token>& program,
+    Lexer& program,
     int expression_precedence,
     std::unique_ptr<ExprAST> lhs
 );
 std::unique_ptr<ExprAST> parse_expr(
-    std::deque<Token>& program
+    Lexer& program
 );
 
 std::unique_ptr<FunctionPrototypeAST> parse_function_proto(
-    std::deque<Token>& program
+    Lexer& program
 );
 std::unique_ptr<FunctionAST> parse_function_definition(
-    std::deque<Token>& program
+    Lexer& program
 );
 std::unique_ptr<FunctionAST> parse_top_level_expr(
-    std::deque<Token>& program
+    Lexer& program
 );
 std::unique_ptr<FunctionPrototypeAST> parse_extern(
-    std::deque<Token>& program
+    Lexer& program
 );
 
 std::vector<ParsedAstContentType> parse_program(
-    std::deque<Token>& program
+    Lexer& program
 );
 
 }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -1,5 +1,6 @@
 #include <deque>
 #include <memory>
+#include <gtest/gtest.h>
 
 #include "ast.hpp"
 #include "lexer.hpp"
@@ -7,43 +8,39 @@
 namespace kccani
 {
 
-std::unique_ptr<ExprAST> parse_number_expr(
-    Lexer& program
-);
-std::unique_ptr<ExprAST> parse_parenthesized_expr(
-    Lexer& program
-);
-std::unique_ptr<ExprAST> parse_identifier_expr(
-    Lexer& program
-);
-std::unique_ptr<ExprAST> parse_primary(
-    Lexer& program
-);
+class Parser
+{
+private:
 
-std::unique_ptr<ExprAST> parse_binary_op_rhs(
-    Lexer& program,
-    int expression_precedence,
-    std::unique_ptr<ExprAST> lhs
-);
-std::unique_ptr<ExprAST> parse_expr(
-    Lexer& program
-);
+    FRIEND_TEST(ParserTests, NumberExpressionsGetParsedAsNumberExpr);
+    FRIEND_TEST(ParserTests, NumberExpressionsGetParsedAsPrimaryExpr);
+    FRIEND_TEST(ParserTests, SimpleBinaryExpressionsGetParsed);
+    FRIEND_TEST(ParserTests, BinaryOperatorExpressionsGetParsedWithCorrectPrecedence1);
+    FRIEND_TEST(ParserTests, BinaryOperatorExpressionsGetParsedWithCorrectPrecedence2);
+    FRIEND_TEST(ParserTests, BracketedBinaryExpressionsGetParsed);
+    FRIEND_TEST(ParserTests, GeneratesTheCorrectParsedExpression);
+    FRIEND_TEST(ParserTests, ParsesFunctionPrototypeCorrectly);
 
-std::unique_ptr<FunctionPrototypeAST> parse_function_proto(
-    Lexer& program
-);
-std::unique_ptr<FunctionAST> parse_function_definition(
-    Lexer& program
-);
-std::unique_ptr<FunctionAST> parse_top_level_expr(
-    Lexer& program
-);
-std::unique_ptr<FunctionPrototypeAST> parse_extern(
-    Lexer& program
-);
+    Lexer& program;
 
-std::vector<ParsedAstContentType> parse_program(
-    Lexer& program
-);
+    std::unique_ptr<ExprAST> parse_number_expr();
+    std::unique_ptr<ExprAST> parse_parenthesized_expr();
+    std::unique_ptr<ExprAST> parse_identifier_expr();
+    std::unique_ptr<ExprAST> parse_primary();
+    std::unique_ptr<ExprAST> parse_binary_op_rhs(int, std::unique_ptr<ExprAST>);
+    std::unique_ptr<ExprAST> parse_expr();
+
+    std::unique_ptr<FunctionPrototypeAST> parse_function_proto();
+    std::unique_ptr<FunctionAST> parse_function_definition();
+    std::unique_ptr<FunctionAST> parse_top_level_expr();
+    std::unique_ptr<FunctionPrototypeAST> parse_extern();
+
+public:
+    Parser(Lexer& lexer);
+    virtual ParsedAstContentType get();
+    std::vector<ParsedAstContentType> fetch_all();
+
+    Parser operator>>(ParsedAstContentType& ast);
+};
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 enable_testing()
 
-add_executable(compiler_tests main.cpp test_lexer.cpp test_parser.cpp)
-target_link_libraries(compiler_tests compiler_lib gtest)
+add_executable(compiler_tests main.cpp test_lexer.cpp test_parser.cpp test_codegen.cpp)
+target_link_libraries(compiler_tests compiler_lib gtest gmock)
 add_test(
     NAME compiler_tests
     COMMAND compiler_tests . --gtest_output=xml:unit_tests_results/

--- a/test/test_codegen.cpp
+++ b/test/test_codegen.cpp
@@ -14,7 +14,8 @@ TEST(CodegenTests, LlvmIrIsGeneratedFromASimpleFunctionDefnAndCall)
     if (!fin.is_open())
         FAIL();
     kccani::Lexer lexer(fin);
-    auto ast_list = parse_program(lexer);
+    auto parser = kccani::Parser(lexer);
+    auto ast_list = parser.fetch_all();
     CodeGeneratorLLVM codegen;
 
     for (const auto &ast : ast_list)

--- a/test/test_codegen.cpp
+++ b/test/test_codegen.cpp
@@ -13,8 +13,8 @@ TEST(CodegenTests, LlvmIrIsGeneratedFromASimpleFunctionDefnAndCall)
     std::ifstream fin("../../test/sample_programs/test_simple.kld", std::ios::in);
     if (!fin.is_open())
         FAIL();
-    auto token_list = kccani::tokenize(fin);
-    auto ast_list = parse_program(token_list);
+    kccani::Lexer lexer(fin);
+    auto ast_list = parse_program(lexer);
     CodeGeneratorLLVM codegen;
 
     for (const auto &ast : ast_list)

--- a/test/test_lexer.cpp
+++ b/test/test_lexer.cpp
@@ -11,11 +11,14 @@ TEST(LexerTests, OutputsTheRightNumberOfTokensOfCorrectTypes)
     std::ifstream fin("../../test/sample_programs/test_simple.kld", std::ios::in);
     if (!fin.is_open())
         FAIL();
-    auto token_list = kccani::tokenize(fin);
-    
+    kccani::Lexer lexer(fin);
+    auto token_list = lexer.fetch_all();
+
     int count_def = 0, count_var = 0, count_val = 0, count_op = 0, count_eof = 0;
-    for (auto token : token_list)
+    while (!token_list.empty())
     {
+        auto token = token_list.front();
+        token_list.pop();
         switch (token.type)
         {
         case Token::TokenType::TOKEN_DEF:

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2,19 +2,42 @@
 #include <iostream>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "../src/ast.hpp"
+#include "../src/lexer.hpp"
 #include "../src/parser.hpp"
 
 using namespace kccani;
+
+
+class MockLexer : public Lexer
+{
+public:
+    MockLexer(std::istream& stream) : Lexer(stream) {};
+    MOCK_METHOD(Token, get, (), (override));
+    MOCK_METHOD(Token, peek, (), (override));
+};
+
 
 TEST(ParserTests, NumberExpressionsGetParsedAsNumberExpr)
 {
     // 3
     std::deque<Token> token_list = {
         Token{Token::TokenType::TOKEN_NUMBER, 3.0},
+        Token{Token::TokenType::TOKEN_EOF},
     };
-    std::unique_ptr<ExprAST> expr = parse_number_expr(token_list);
+    auto lexer = MockLexer(std::cin);
+    ON_CALL(lexer, get()).WillByDefault([&token_list]() -> Token {
+        auto value = token_list.front();
+        token_list.pop_front();
+        return value;
+    });
+    ON_CALL(lexer, peek()).WillByDefault([&token_list]() -> Token {
+        return token_list.front();
+    });
+
+    std::unique_ptr<ExprAST> expr = parse_number_expr(lexer);
     NumberExprAST* ast(dynamic_cast<NumberExprAST*>(expr.get()));
     ASSERT_EQ(ast->value, 3.0);
 }
@@ -24,8 +47,19 @@ TEST(ParserTests, NumberExpressionsGetParsedAsPrimaryExpr)
     // 3
     std::deque<Token> token_list = {
         Token{Token::TokenType::TOKEN_NUMBER, 3.0},
+        Token{Token::TokenType::TOKEN_EOF},
     };
-    std::unique_ptr<ExprAST> expr = parse_primary(token_list);
+    auto lexer = MockLexer(std::cin);
+    ON_CALL(lexer, get()).WillByDefault([&token_list]() -> Token {
+        auto value = token_list.front();
+        token_list.pop_front();
+        return value;
+    });
+    ON_CALL(lexer, peek()).WillByDefault([&token_list]() -> Token {
+        return token_list.front();
+    });
+
+    std::unique_ptr<ExprAST> expr = parse_primary(lexer);
     NumberExprAST* ast(dynamic_cast<NumberExprAST*>(expr.get()));
     ASSERT_EQ(ast->value, 3.0);
 }
@@ -37,8 +71,19 @@ TEST(ParserTests, SimpleBinaryExpressionsGetParsed)
         Token{Token::TokenType::TOKEN_NUMBER, 3.0},
         Token{Token::TokenType::TOKEN_SPECIAL, '+'},
         Token{Token::TokenType::TOKEN_NUMBER, 2.0},
+        Token{Token::TokenType::TOKEN_EOF},
     };
-    std::unique_ptr<ExprAST> expr = parse_expr(token_list);
+    auto lexer = MockLexer(std::cin);
+    ON_CALL(lexer, get()).WillByDefault([&token_list]() -> Token {
+        auto value = token_list.front();
+        token_list.pop_front();
+        return value;
+    });
+    ON_CALL(lexer, peek()).WillByDefault([&token_list]() -> Token {
+        return token_list.front();
+    });
+
+    std::unique_ptr<ExprAST> expr = parse_expr(lexer);
     BinaryExprAST* ast = dynamic_cast<BinaryExprAST*>(expr.get());
     ASSERT_EQ(ast->opcode, '+');
     NumberExprAST* lhs = dynamic_cast<NumberExprAST*>(ast->lhs.get());
@@ -56,8 +101,19 @@ TEST(ParserTests, BinaryOperatorExpressionsGetParsedWithCorrectPrecedence1)
         Token{Token::TokenType::TOKEN_NUMBER, 2.0},
         Token{Token::TokenType::TOKEN_SPECIAL, '*'},
         Token{Token::TokenType::TOKEN_NUMBER, 5.0},
+        Token{Token::TokenType::TOKEN_EOF},
     };
-    std::unique_ptr<ExprAST> expr = parse_expr(token_list);
+    auto lexer = MockLexer(std::cin);
+    ON_CALL(lexer, get()).WillByDefault([&token_list]() -> Token {
+        auto value = token_list.front();
+        token_list.pop_front();
+        return value;
+    });
+    ON_CALL(lexer, peek()).WillByDefault([&token_list]() -> Token {
+        return token_list.front();
+    });
+
+    std::unique_ptr<ExprAST> expr = parse_expr(lexer);
     BinaryExprAST* ast = dynamic_cast<BinaryExprAST*>(expr.get());
     ASSERT_EQ(ast->opcode, '+');
     NumberExprAST* lhs = dynamic_cast<NumberExprAST*>(ast->lhs.get());
@@ -79,8 +135,19 @@ TEST(ParserTests, BinaryOperatorExpressionsGetParsedWithCorrectPrecedence2)
         Token{Token::TokenType::TOKEN_NUMBER, 2.0},
         Token{Token::TokenType::TOKEN_SPECIAL, '+'},
         Token{Token::TokenType::TOKEN_NUMBER, 5.0},
+        Token{Token::TokenType::TOKEN_EOF},
     };
-    std::unique_ptr<ExprAST> expr = parse_expr(token_list);
+    auto lexer = MockLexer(std::cin);
+    ON_CALL(lexer, get()).WillByDefault([&token_list]() -> Token {
+        auto value = token_list.front();
+        token_list.pop_front();
+        return value;
+    });
+    ON_CALL(lexer, peek()).WillByDefault([&token_list]() -> Token {
+        return token_list.front();
+    });
+
+    std::unique_ptr<ExprAST> expr = parse_expr(lexer);
     BinaryExprAST* ast = dynamic_cast<BinaryExprAST*>(expr.get());
     ASSERT_EQ(ast->opcode, '+');
     BinaryExprAST* lhs = dynamic_cast<BinaryExprAST*>(ast->lhs.get());
@@ -102,8 +169,19 @@ TEST(ParserTests, BracketedBinaryExpressionsGetParsed)
         Token{Token::TokenType::TOKEN_SPECIAL, '+'},
         Token{Token::TokenType::TOKEN_NUMBER, 2.0},
         Token{Token::TokenType::TOKEN_SPECIAL, ')'},
+        Token{Token::TokenType::TOKEN_EOF},
     };
-    std::unique_ptr<ExprAST> expr = parse_primary(token_list);
+    auto lexer = MockLexer(std::cin);
+    ON_CALL(lexer, get()).WillByDefault([&token_list]() -> Token {
+        auto value = token_list.front();
+        token_list.pop_front();
+        return value;
+    });
+    ON_CALL(lexer, peek()).WillByDefault([&token_list]() -> Token {
+        return token_list.front();
+    });
+
+    std::unique_ptr<ExprAST> expr = parse_primary(lexer);
     BinaryExprAST* ast = dynamic_cast<BinaryExprAST*>(expr.get());
     ASSERT_EQ(ast->opcode, '+');
     NumberExprAST* lhs = dynamic_cast<NumberExprAST*>(ast->lhs.get());
@@ -125,8 +203,19 @@ TEST(ParserTests, GeneratesTheCorrectParsedExpression)
         Token{Token::TokenType::TOKEN_SPECIAL, '*'},
         Token{Token::TokenType::TOKEN_NUMBER, 4.0},
         Token{Token::TokenType::TOKEN_SPECIAL, ')'},
+        Token{Token::TokenType::TOKEN_EOF},
     };
-    std::unique_ptr<ExprAST> expr = parse_expr(token_list);
+    auto lexer = MockLexer(std::cin);
+    ON_CALL(lexer, get()).WillByDefault([&token_list]() -> Token {
+        auto value = token_list.front();
+        token_list.pop_front();
+        return value;
+    });
+    ON_CALL(lexer, peek()).WillByDefault([&token_list]() -> Token {
+        return token_list.front();
+    });
+
+    std::unique_ptr<ExprAST> expr = parse_expr(lexer);
     BinaryExprAST* ast(dynamic_cast<BinaryExprAST*>(expr.get()));
     ASSERT_EQ(
         expr->to_string(),
@@ -142,8 +231,19 @@ TEST(ParserTests, ParsesFunctionPrototypeCorrectly)
         Token{Token::TokenType::TOKEN_IDENTIFIER, "x"},
         Token{Token::TokenType::TOKEN_IDENTIFIER, "y"},
         Token{Token::TokenType::TOKEN_SPECIAL, ')'},
+        Token{Token::TokenType::TOKEN_EOF},
     };
-    std::unique_ptr<FunctionPrototypeAST> fn = parse_function_proto(token_list);
+    auto lexer = MockLexer(std::cin);
+    ON_CALL(lexer, get()).WillByDefault([&token_list]() -> Token {
+        auto value = token_list.front();
+        token_list.pop_front();
+        return value;
+    });
+    ON_CALL(lexer, peek()).WillByDefault([&token_list]() -> Token {
+        return token_list.front();
+    });
+
+    std::unique_ptr<FunctionPrototypeAST> fn = parse_function_proto(lexer);
     FunctionPrototypeAST* ast(dynamic_cast<FunctionPrototypeAST*>(fn.get()));
     ASSERT_EQ(ast->to_string(), "def func(x, y)");
 }
@@ -153,8 +253,8 @@ TEST(ParserTests, TopLevelParsingParsesASimpleFileWithFunctionDefinitions)
     std::ifstream fin("../../test/sample_programs/test_simple.kld", std::ios::in);
     if (!fin.is_open())
         FAIL();
-    auto token_list = kccani::tokenize(fin);
-    auto ast_list = parse_program(token_list);
+    auto lexer = kccani::Lexer(fin);
+    auto ast_list = parse_program(lexer);
 
     ASSERT_EQ(ast_list.size(), 2);
 
@@ -172,7 +272,7 @@ TEST(ParserTests, TopLevelParsingParsesASimpleFileWithExternAndCall)
     std::ifstream fin("../../test/sample_programs/test_extern.kld", std::ios::in);
     if (!fin.is_open())
         FAIL();
-    auto token_list = kccani::tokenize(fin);
+    Lexer token_list = kccani::Lexer(fin);
     auto ast_list = parse_program(token_list);
 
     ASSERT_EQ(ast_list.size(), 2);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -8,8 +8,8 @@
 #include "../src/lexer.hpp"
 #include "../src/parser.hpp"
 
-using namespace kccani;
-
+namespace kccani 
+{
 
 class MockLexer : public Lexer
 {
@@ -37,7 +37,9 @@ TEST(ParserTests, NumberExpressionsGetParsedAsNumberExpr)
         return token_list.front();
     });
 
-    std::unique_ptr<ExprAST> expr = parse_number_expr(lexer);
+    auto parser = Parser(lexer);
+    std::unique_ptr<ExprAST> expr = parser.parse_number_expr();
+
     NumberExprAST* ast(dynamic_cast<NumberExprAST*>(expr.get()));
     ASSERT_EQ(ast->value, 3.0);
 }
@@ -59,7 +61,9 @@ TEST(ParserTests, NumberExpressionsGetParsedAsPrimaryExpr)
         return token_list.front();
     });
 
-    std::unique_ptr<ExprAST> expr = parse_primary(lexer);
+    auto parser = Parser(lexer);
+    std::unique_ptr<ExprAST> expr = parser.parse_primary();
+
     NumberExprAST* ast(dynamic_cast<NumberExprAST*>(expr.get()));
     ASSERT_EQ(ast->value, 3.0);
 }
@@ -83,7 +87,9 @@ TEST(ParserTests, SimpleBinaryExpressionsGetParsed)
         return token_list.front();
     });
 
-    std::unique_ptr<ExprAST> expr = parse_expr(lexer);
+    auto parser = Parser(lexer);
+    std::unique_ptr<ExprAST> expr = parser.parse_expr();
+
     BinaryExprAST* ast = dynamic_cast<BinaryExprAST*>(expr.get());
     ASSERT_EQ(ast->opcode, '+');
     NumberExprAST* lhs = dynamic_cast<NumberExprAST*>(ast->lhs.get());
@@ -113,7 +119,9 @@ TEST(ParserTests, BinaryOperatorExpressionsGetParsedWithCorrectPrecedence1)
         return token_list.front();
     });
 
-    std::unique_ptr<ExprAST> expr = parse_expr(lexer);
+    auto parser = Parser(lexer);
+    std::unique_ptr<ExprAST> expr = parser.parse_expr();
+
     BinaryExprAST* ast = dynamic_cast<BinaryExprAST*>(expr.get());
     ASSERT_EQ(ast->opcode, '+');
     NumberExprAST* lhs = dynamic_cast<NumberExprAST*>(ast->lhs.get());
@@ -147,7 +155,9 @@ TEST(ParserTests, BinaryOperatorExpressionsGetParsedWithCorrectPrecedence2)
         return token_list.front();
     });
 
-    std::unique_ptr<ExprAST> expr = parse_expr(lexer);
+    auto parser = Parser(lexer);
+    std::unique_ptr<ExprAST> expr = parser.parse_expr();
+
     BinaryExprAST* ast = dynamic_cast<BinaryExprAST*>(expr.get());
     ASSERT_EQ(ast->opcode, '+');
     BinaryExprAST* lhs = dynamic_cast<BinaryExprAST*>(ast->lhs.get());
@@ -181,7 +191,9 @@ TEST(ParserTests, BracketedBinaryExpressionsGetParsed)
         return token_list.front();
     });
 
-    std::unique_ptr<ExprAST> expr = parse_primary(lexer);
+    auto parser = Parser(lexer);
+    std::unique_ptr<ExprAST> expr = parser.parse_primary();
+
     BinaryExprAST* ast = dynamic_cast<BinaryExprAST*>(expr.get());
     ASSERT_EQ(ast->opcode, '+');
     NumberExprAST* lhs = dynamic_cast<NumberExprAST*>(ast->lhs.get());
@@ -215,7 +227,8 @@ TEST(ParserTests, GeneratesTheCorrectParsedExpression)
         return token_list.front();
     });
 
-    std::unique_ptr<ExprAST> expr = parse_expr(lexer);
+    auto parser = Parser(lexer);
+    std::unique_ptr<ExprAST> expr = parser.parse_expr();
     BinaryExprAST* ast(dynamic_cast<BinaryExprAST*>(expr.get()));
     ASSERT_EQ(
         expr->to_string(),
@@ -243,7 +256,9 @@ TEST(ParserTests, ParsesFunctionPrototypeCorrectly)
         return token_list.front();
     });
 
-    std::unique_ptr<FunctionPrototypeAST> fn = parse_function_proto(lexer);
+    auto parser = Parser(lexer);
+    std::unique_ptr<FunctionPrototypeAST> fn = parser.parse_function_proto();
+
     FunctionPrototypeAST* ast(dynamic_cast<FunctionPrototypeAST*>(fn.get()));
     ASSERT_EQ(ast->to_string(), "def func(x, y)");
 }
@@ -253,8 +268,9 @@ TEST(ParserTests, TopLevelParsingParsesASimpleFileWithFunctionDefinitions)
     std::ifstream fin("../../test/sample_programs/test_simple.kld", std::ios::in);
     if (!fin.is_open())
         FAIL();
-    auto lexer = kccani::Lexer(fin);
-    auto ast_list = parse_program(lexer);
+    auto lexer = Lexer(fin);
+    auto parser = Parser(lexer);
+    auto ast_list = parser.fetch_all();
 
     ASSERT_EQ(ast_list.size(), 2);
 
@@ -272,8 +288,9 @@ TEST(ParserTests, TopLevelParsingParsesASimpleFileWithExternAndCall)
     std::ifstream fin("../../test/sample_programs/test_extern.kld", std::ios::in);
     if (!fin.is_open())
         FAIL();
-    Lexer token_list = kccani::Lexer(fin);
-    auto ast_list = parse_program(token_list);
+    auto lexer = Lexer(fin);
+    auto parser = Parser(lexer);
+    auto ast_list = parser.fetch_all();
 
     ASSERT_EQ(ast_list.size(), 2);
 
@@ -284,4 +301,6 @@ TEST(ParserTests, TopLevelParsingParsesASimpleFileWithExternAndCall)
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<ExprAST>>(ast_list[1]));
     auto ast_2 = std::get<std::unique_ptr<ExprAST>>(std::move(ast_list[1]));
     ASSERT_EQ(ast_2->to_string(), "atan2(13.000000, (5.000000) + (8.000000))");
+}
+
 }


### PR DESCRIPTION
Instead of buffering each output into a deque, we are now treating them as streams, and only reading from the input when we need to have an output. This will help in the REPL mode.